### PR TITLE
Keyword tag change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woorank-theme",
-  "version": "8.4.2",
+  "version": "8.4.3",
   "description": "Woorank Living Style guide",
   "author": "@woorank",
   "license": "ISC",

--- a/src/sass/components/__components.scss
+++ b/src/sass/components/__components.scss
@@ -18,7 +18,7 @@
   'dropdown',
   'form',
   'hero-banner',
-  'keyword-tag',
+  'keyword-default',
   'label',
   'list-group',
   'modal',

--- a/src/sass/components/_keyword-default.scss
+++ b/src/sass/components/_keyword-default.scss
@@ -1,21 +1,21 @@
 /*
-Keyword Tags
+Keyword Default Tags
 
 Markup:
-<div class="keyword-tag {{modifier_class}}">
-  <div class="keyword-tag-inner">Keyword</div>
+<div class="keyword-default {{modifier_class}}">
+  <div class="keyword-default-inner">keyword-default</div>
 </div>
 
-.keyword-tag-primary - Primary
-.keyword-tag-success - Success
-.keyword-tag-warning - Warning
-.keyword-tag-error - Error
-.keyword-tag-grey - Grey
+.keyword-default-primary - Primary
+.keyword-default-success - Success
+.keyword-default-warning - Warning
+.keyword-default-error - Error
+.keyword-default-grey - Grey
 
-Styleguide Components.Keyword-Tags
+Styleguide Components.keyword-defaults
 */
 
-.keyword-tag {
+.keyword-default {
   background-color: $white;
   border-radius: $border-radius-base;
   border: 1px solid $border-color;
@@ -29,7 +29,7 @@ Styleguide Components.Keyword-Tags
   margin-right: 5px;
   cursor: pointer;
 
-  .keyword-tag-inner {
+  .keyword-default-inner {
     display: block;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -45,7 +45,7 @@ Styleguide Components.Keyword-Tags
   }
 }
 
-.keyword-tag {
+.keyword-default {
   &::before {
     content: "";
     position: absolute;
@@ -86,7 +86,7 @@ Styleguide Components.Keyword-Tags
   }
 
   @each $color, $colorValue in $colors {
-    &.keyword-tag-#{$color} {
+    &.keyword-default-#{$color} {
       border-color: $colorValue;
       background-color: $colorValue;
 

--- a/woo-components/package.json
+++ b/woo-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woo-components",
-  "version": "8.4.2",
+  "version": "8.4.3",
   "description": "Woo-components",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
> Replace the class "Keyword-tag" for "Keyword-default" on Styleguide.
> Bump version to v8.4.3