### PR TITLE
Input focus zindex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woorank-theme",
-  "version": "10.1.3",
+  "version": "10.1.4",
   "description": "Woorank Living Style guide",
   "author": "@woorank",
   "license": "ISC",

--- a/src/sass/patterns/_generation-bar-in-navbar-pro-user.scss
+++ b/src/sass/patterns/_generation-bar-in-navbar-pro-user.scss
@@ -264,7 +264,7 @@ Styleguide Patterns.Generation-bar-in-navbar-Pro-User
     .input-group-btn {
       position: relative;
       text-align: right;
-      z-index: 2;
+      z-index: 3;
 
       .generation-bar-btn {
         border-radius: 0 0 $border-radius-base $border-radius-base;


### PR DESCRIPTION
* Fix for InputGenbar due to Bootstrap 3.3.7 updates
(z-index of input increased, hence hides the genbar-options-button)